### PR TITLE
Add macFUSE mounting support to pure path

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -10,10 +10,13 @@ fn main() {
 
     if matches!(
         target_os.as_str(),
-        "linux" | "freebsd" | "dragonfly" | "openbsd" | "netbsd"
+        "linux" | "freebsd" | "dragonfly" | "openbsd" | "netbsd" | "macos"
     ) && cfg!(not(feature = "libfuse"))
     {
         println!("cargo:rustc-cfg=fuser_mount_impl=\"pure-rust\"");
+        if target_os == "macos" {
+            println!("cargo:rustc-cfg=feature=\"macfuse-4-compat\"");
+        }
     } else if target_os == "macos" {
         pkg_config::Config::new()
             .atleast_version("2.6.0")

--- a/src/mnt/fuse_pure.rs
+++ b/src/mnt/fuse_pure.rs
@@ -477,6 +477,7 @@ fn fuse_mount_mount_macfuse(
     }
 
     builder
+        .env("_FUSE_CALL_BY_LIB", "1")
         .env("_FUSE_COMMVERS", "2")
         .env(FUSERMOUNT_COMM_ENV, child_socket.as_raw_fd().to_string())
         .arg(mountpoint);

--- a/src/mnt/fuse_pure.rs
+++ b/src/mnt/fuse_pure.rs
@@ -309,18 +309,19 @@ fn fuse_mount_fusermount(
     let fsname = options
         .iter()
         .find_map(|opt| match opt {
-            MountOption::FSName(name) => Some(name.as_str()),
+            MountOption::FSName(name) => Some(name.clone()),
             _ => None,
         })
         .unwrap_or_else(|| {
             Path::new(mountpoint)
                 .file_name()
                 .and_then(|name| name.to_str())
-                .unwrap_or_else(|| mountpoint.to_string_lossy().as_ref())
+                .map(|s| s.to_owned())
+                .unwrap_or_else(|| mountpoint.to_string_lossy().into_owned())
         });
 
     if is_macfuse_helper {
-        builder.arg(fsname).arg(mountpoint);
+        builder.arg(&fsname).arg(mountpoint);
     } else {
         builder.arg("--").arg(mountpoint);
     }

--- a/src/mnt/fuse_pure.rs
+++ b/src/mnt/fuse_pure.rs
@@ -477,7 +477,6 @@ fn fuse_mount_mount_macfuse(
     }
 
     builder
-        .env("_FUSE_CALL_BY_LIB", "1")
         .env("_FUSE_COMMVERS", "2")
         .env(FUSERMOUNT_COMM_ENV, child_socket.as_raw_fd().to_string())
         .arg(mountpoint);

--- a/src/mnt/fuse_pure.rs
+++ b/src/mnt/fuse_pure.rs
@@ -143,7 +143,9 @@ fn fuse_unmount_pure(mountpoint: &CStr) {
         }
     }
 
-    let mut builder = Command::new(detect_fusermount_bin());
+    let (fusermount_bin, _) = detect_fusermount_bin();
+
+    let mut builder = Command::new(&fusermount_bin);
     builder.stdout(Stdio::piped()).stderr(Stdio::piped());
     builder
         .arg("-u")

--- a/src/mnt/fuse_pure.rs
+++ b/src/mnt/fuse_pure.rs
@@ -339,7 +339,7 @@ fn fuse_mount_fusermount(
         builder.env("_FUSE_COMMVERS", "2");
     }
 
-    let fusermount_child = builder.spawn()?;
+    let mut fusermount_child = builder.spawn()?;
 
     drop(child_socket); // close socket in parent
 

--- a/src/mnt/fuse_pure.rs
+++ b/src/mnt/fuse_pure.rs
@@ -478,7 +478,7 @@ fn fuse_mount_mount_macfuse(
         .env(FUSERMOUNT_COMM_ENV, child_socket.as_raw_fd().to_string())
         .arg(mountpoint);
 
-    let fusermount_child = builder.spawn()?;
+    let mut fusermount_child = builder.spawn()?;
 
     drop(child_socket);
 


### PR DESCRIPTION
## Summary
- enable the pure-Rust mount implementation for macOS targets
- add macFUSE helper detection and _FUSE_COMMVERS handling when mounting
- fall back to helper-based mounting if direct mounting fails

## Testing
- cargo fmt


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692cec58e9ac832ab5407dc14887a7fe)